### PR TITLE
method setColRowStart should be public

### DIFF
--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -94,6 +94,7 @@ class Adafruit_ST77xx : public Adafruit_SPITFT {
 
     void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
     void setRotation(uint8_t r);
+    void setColRowStart(int8_t col, int8_t row);
 
   protected:
     uint8_t _colstart = 0, ///< Some displays need this changed to offset
@@ -102,7 +103,6 @@ class Adafruit_ST77xx : public Adafruit_SPITFT {
     void    begin(uint32_t freq = 0);
     void    commonInit(const uint8_t *cmdList);
     void    displayInit(const uint8_t *addr);
-    void    setColRowStart(int8_t col, int8_t row);
 };
 
 #endif // _ADAFRUIT_ST77XXH_


### PR DESCRIPTION
Due to wide-using noname shields (based on ST77xx controllers), users often encounter un-expectable hardware realizations with disordered cols/rows start offsets (offsets differ from geniue Adafriut shields). 

Adafruit-ST7735-Library has method (setColRowStart) for resolve this trouble, but it is protected. So it is necessary to use wrapper-inheritor for access protected method (or variables).

But such wrapper has no additional functionality and, therefore, necessity.

Please move setColRowStart to public section for use without subclasses.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
